### PR TITLE
Fix deprecation warning for app.del

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -66,7 +66,7 @@ export function patch(path: string = '*', middleware: Middleware[] = []) {
 
 
 export function del(path: string = '*', middleware: Middleware[] = []) {
-  return route('del', path, middleware);
+  return route('delete', path, middleware);
 };
 
 


### PR DESCRIPTION
When using Express v4 a deprecation warning gets logged:
express deprecated app.del: Use app.delete instead node_modules/express-decorators/dist/lib/index.js:147:30

See https://github.com/expressjs/express/wiki/Migrating-from-3.x-to-4.x#deprecated-since-3x