### PR TITLE
express deprecated app.del

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -71,7 +71,7 @@ export function patch(path: string = '*', middleware: Middleware[] = []) {
 }
 
 export function del(path: string = '*', middleware: Middleware[] = []) {
-  return route('del', path, middleware);
+  return route('delete', path, middleware);
 }
 
 export function options(path: string = '*', middleware: Middleware[] = []) {


### PR DESCRIPTION
app.del was deprecated!

https://github.com/expressjs/express/wiki/Migrating-from-3.x-to-4.x#deprecated-since-3x